### PR TITLE
chore: use tldr as file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Prepare the required files:
 ## Test & Run
 - In your Obsidian Vault, go to Community Plugins, and enable the plugin
 - On the ribbon, click on the `dice` icon. When hovered over, it displays `New Tldrawing
-- Click on it. That will create a file with extension `.tldraw` and will activate the `obsidian-tldraw-plugin`.
+- Click on it. That will create a file with extension `.tldr` and will activate the `obsidian-tldraw-plugin`.
 
 ## Features
 
 Current features:
 
-- Ribbon icon, which when clicked, creates a file with extension `.tldraw` opens up Tldraw.
-- Any file with extension `.tldraw` opens up Tldraw.
+- Ribbon icon, which when clicked, creates a file with extension `.tldr` opens up Tldraw.
+- Any file with extension `.tldr` opens up Tldraw.
 
 [This GitHub Project](https://github.com/users/juliusgb/projects/3/views/1) contains most up-to-date plans.
 

--- a/guides/development.md
+++ b/guides/development.md
@@ -8,7 +8,7 @@ To install:
 To run:
 - in your Obsidian Vault, go to Community Plugins, and enable the plugin
 - on the ribbon, click on the `dice` icon. When hovered over, it displays `New Tldrawing`
-- Click on it. That will create a file with extension `.tldraw` and will activate the `obsidian-tldraw-plugin`
+- Click on it. That will create a file with extension `.tldr` and will activate the `obsidian-tldraw-plugin`
 
 ## Development workflow
 

--- a/src/TLdrawView.tsx
+++ b/src/TLdrawView.tsx
@@ -47,7 +47,7 @@ export default class TLdrawView extends TextFileView {
 
 		// when the loading of the vault into the memory is done
 		this.app.workspace.onLayoutReady(async () => {
-			this.compatibilityMode = this.file.extension === "tldraw";
+			this.compatibilityMode = this.file.extension === "tldr";
 			await this.plugin.loadSettings();
 
 			debug({where:"TLdrawView.setViewData",file:this.file.name, data:data, before:"checkingDataForNull"})
@@ -70,7 +70,7 @@ export default class TLdrawView extends TextFileView {
 				this.tldrawData.disableCompression = true;
 			}
 			else {
-				// TODO: process .tldraw.md files
+				// TODO: process .tldr.md files
 				this.tldrawData.disableCompression = false;
 			}
 			// use tldrawDataJson

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,7 +46,7 @@ export default class TldrawPlugin extends Plugin {
 		);
 
 		// Register the extensions you want the view to handle.
-		this.registerExtensions(["tldraw"], VIEW_TYPE_TLDRAW_EMBED);
+		this.registerExtensions(["tldr"], VIEW_TYPE_TLDRAW_EMBED);
 
 		this.registerCommands();
 		this.registerEventListeners();

--- a/src/utils/FileUtils.ts
+++ b/src/utils/FileUtils.ts
@@ -9,9 +9,9 @@ export function getDrawingFilename(settings: TldrawSettings): string {
 
 	const filenameWithDateTime = settings.drawingFilenameDateTime !== "" ? dateTimeValue : "";
 
-	const markdownFileExtension = settings.useTldrawExtension ? ".tldraw.md" : ".md";
+	const markdownFileExtension = settings.useTldrawExtension ? ".tldr.md" : ".md";
 
-	const fileExtension = settings.compatibilityMode ? ".tldraw" : markdownFileExtension;
+	const fileExtension = settings.compatibilityMode ? ".tldr" : markdownFileExtension;
 
 	return settings.drawingFilenamePrefix + filenameWithDateTime + fileExtension ;
 }
@@ -59,8 +59,8 @@ export function getNewUniqueFilepath(
 
 	let i = 0;
 
-	const extension = filename.endsWith(".tldraw.md")
-		? ".tldraw.md"
+	const extension = filename.endsWith(".tldr.md")
+		? ".tldr.md"
 		: filename.slice(filename.lastIndexOf("."));
 
 	while (file) {


### PR DESCRIPTION
Use `.tldr` as file extension to be to be consistent with other tldraw tools and documentation.