### PR TITLE
chore: remove superfluous console.log

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -78,13 +78,6 @@ export default class TldrawPlugin extends Plugin {
 
 	private registerEventListeners() {
 		//debug({where:"TLdrawPlugin.registerCommands",});
-
-		// If the plugin hooks up any global DOM events (on parts of the app that doesn't belong to this plugin)
-		// Using this function will automatically remove the event listener when this plugin is disabled.
-		this.registerDomEvent(document, 'click', (evt: MouseEvent) => {
-			console.log('click', evt);
-		});
-
 		// When registering intervals, this function will automatically clear the interval when the plugin is disabled.
 		this.registerInterval(window.setInterval(() => console.log('setInterval'), 5 * 60 * 1000));
 	}


### PR DESCRIPTION
This console.log doesn't serve any purpose.