### PR TITLE
Allow styles to pop over the canvas and make canvas height 100%

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,7 @@ html,
 	font-family: sans-serif;
 	text-align: center;
 	height: 100%; /* keeps the gray background */
+	width: 100%;
 }
 
 /* TODO: remove h1 element and css after tests */
@@ -25,9 +26,11 @@ html,
 
 .tldraw-wrapper {
 	position: relative;
-	/* keep 20% of .tldrawApp.width for the styles pop-up*/
-	max-width: 80%;
-	min-height: 85%;
+	height: 100%;
 	margin-right: 5px; /* affects room on the right*/
 	margin-left: 5px;
+}
+
+[data-radix-popper-content-wrapper]:has(#TD-StylesMenu) {
+	position: absolute !important;
 }

--- a/styles.css
+++ b/styles.css
@@ -31,6 +31,6 @@ html,
 	margin-left: 5px;
 }
 
-[data-radix-popper-content-wrapper]:has(#TD-StylesMenu) {
+[data-radix-popper-content-wrapper]:has(#TD-StylesMenu, #TD-ContextMenu, #TD-Menu) {
 	position: absolute !important;
 }


### PR DESCRIPTION
Hi @juliusgb, thanks for making this plugin, its been very useful!

I noticed the canvas was not stretched the full width of the page and the reason was to make room for the styles popover. This change should allow for the styles popover to go above the canvas while also allowing the canvas to stretch the full width of the page.